### PR TITLE
Update image for exposing custom package configuration artifact

### DIFF
--- a/rpminspect.fmf
+++ b/rpminspect.fmf
@@ -15,7 +15,7 @@ description: |
 provision:
     how: container
     # source: https://github.com/fedora-ci/rpminspect-image
-    image: quay.io/fedoraci/rpminspect:5e29b5f
+    image: quay.io/fedoraci/rpminspect:3f00076
 
 prepare:
     how: shell


### PR DESCRIPTION
See https://github.com/fedora-ci/rpminspect-runner/commit/fc8f7378b7

Fixes OSCI-3997

----

Picking up the change from https://github.com/fedora-ci/rpminspect-runner/pull/84 . Tests were reported there.